### PR TITLE
Update org.apache.maven.scm dependency and re-release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,4 +15,4 @@ debug: install
 	mvn hpi:run
 
 release:
-	mvn release:clean release:prepare release:perform
+	mvn -Darguments="-DskipTests" release:clean release:prepare release:perform

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,18 @@
           <additionalparam>-Xdoclint:none</additionalparam>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-release-plugin</artifactId>
+        <version>2.5.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.maven.scm</groupId>
+            <artifactId>maven-scm-provider-gitexe</artifactId>
+            <version>1.9.2</version>
+          </dependency>
+        </dependencies>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>aws-device-farm</artifactId>
-  <version>1.3</version>
+  <version>1.4-SNAPSHOT</version>
   <packaging>hpi</packaging>
   
   <name>aws-device-farm</name>
@@ -36,7 +36,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/aws-device-farm-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/aws-device-farm-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/aws-device-farm-plugin</url>
-    <tag>aws-device-farm-1.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
 
   <groupId>org.jenkins-ci.plugins</groupId>
   <artifactId>aws-device-farm</artifactId>
-  <version>1.3-SNAPSHOT</version>
+  <version>1.3</version>
   <packaging>hpi</packaging>
   
   <name>aws-device-farm</name>
@@ -36,6 +36,7 @@
     <connection>scm:git:ssh://github.com/jenkinsci/aws-device-farm-plugin.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/jenkinsci/aws-device-farm-plugin.git</developerConnection>
     <url>https://github.com/jenkinsci/aws-device-farm-plugin</url>
+    <tag>aws-device-farm-1.3</tag>
   </scm>
 
   <developers>


### PR DESCRIPTION
It appears that if your org.apache.maven.scm dependency is old enough, your release:perform actions only deploy SNAPSHOT builds and not actual releases.

Updated the dependency and released version 1.3.

It now be found in the [releases repository](http://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/aws-device-farm/1.3/). Waiting the mirror replication time to confirm that it is propagated to the Jenkins Update Center.