### PR TITLE
Fixed issue - Calabash tags getting ignored while running tests

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -408,10 +408,15 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
                 Upload upload = adf.uploadTest(project, test);
 
+                Map<String, String> parameters = new HashMap<String, String>();
+                if(calabashTags !=null && !calabashTags.isEmpty())
+                {
+                	parameters.put("tags", calabashTags);
+                }
                 testToSchedule = new ScheduleRunTest()
                         .withType(testType)
                         .withTestPackageArn(upload.getArn())
-                        .withParameters(new HashMap<String, String>());
+                        .withParameters(parameters);
                 break;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -409,8 +409,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
                 Upload upload = adf.uploadTest(project, test);
 
                 Map<String, String> parameters = new HashMap<String, String>();
-                if(calabashTags !=null && !calabashTags.isEmpty())
-                {
+                if(calabashTags != null && !calabashTags.isEmpty()){
                 	parameters.put("tags", calabashTags);
                 }
                 testToSchedule = new ScheduleRunTest()


### PR DESCRIPTION
There was a bug in the code that tags were ignored while running calabash tests. I have fixed the issue.
