### PR TITLE
Fix the Null pointer issue - old jobs were failing when the plugin wa…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -501,11 +501,13 @@ public class AWSDeviceFarm {
         }
     }
 
-    public String getOs(String appArtifact) {
+    public String getOs(String appArtifact) throws AWSDeviceFarmException  {
         if (appArtifact.toLowerCase().endsWith("apk")) {
             return "Android";
-        } else {
+        } else if (appArtifact.toLowerCase().endsWith("ipa")) {
             return "IOS";
+        } else {
+            throw new AWSDeviceFarmException(String.format("Unknown app artifact to upload: %s", appArtifact));
         }
     }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -242,7 +242,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             }
 
             // check for Unmetered Devices on Account
-            if (isRunUnmetered) {
+            if (isRunUnmetered != null && isRunUnmetered) {
                 String os = adf.getOs(appArtifact);
                 int unmeteredDeviceCount = adf.getUnmeteredDevices(os);
                 if (unmeteredDeviceCount <= 0) {
@@ -952,9 +952,14 @@ public class AWSDeviceFarmRecorder extends Recorder {
          */
         @SuppressWarnings("unused")
         public FormValidation doCheckIsRunUnmetered(@QueryParameter Boolean isRunUnmetered, @QueryParameter String appArtifact) {
-            if (isRunUnmetered) {
+            if (isRunUnmetered != null && isRunUnmetered) {
                 AWSDeviceFarm adf = getAWSDeviceFarm();
-                String os = adf.getOs(appArtifact);
+                String os = null;
+                try {
+                    os = adf.getOs(appArtifact);
+                } catch(AWSDeviceFarmException e) {
+                    return FormValidation.error(e.getMessage());
+                }
                 if (adf.getUnmeteredDevices(os) <= 0) {
                     return FormValidation.error(String.format("Your account does not have unmetered %s devices.", os));
                 }


### PR DESCRIPTION
The build fails for old jobs which were created before the latest version of plugin was installed. If we go and save the old jobs again (after installing latest version of plugin), build will work fine. 

Reasons for failure 
We added few new parameters in the latest plugin release. If we don't update the old jobs, Jenkins plugin would keep using the old instance of the job which would not have the new parameters. As a result, it would result in a null pointer exception. 

What is the fix 
Whenever we add new parameters to jenkins definition, we need to explicitly do a null check on these parameters to make sure that the old jobs keep working