### PR TITLE
Jenkins Fixes…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -197,7 +197,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadApp(Project project, String appArtifact) throws IOException, AWSDeviceFarmException {
+    public Upload uploadApp(Project project, String appArtifact) throws InterruptedException, IOException, AWSDeviceFarmException {
         AWSDeviceFarmUploadType type;
         if (appArtifact.toLowerCase().endsWith("apk")) {
             type = AWSDeviceFarmUploadType.ANDROID_APP;
@@ -219,7 +219,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, InstrumentationTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, InstrumentationTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getArtifact(), AWSDeviceFarmUploadType.INSTRUMENTATION);
     }
 
@@ -231,7 +231,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, CalabashTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, CalabashTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getFeatures(), AWSDeviceFarmUploadType.CALABASH);
     }
 
@@ -243,7 +243,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, UIAutomatorTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, UIAutomatorTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.UIAUTOMATOR);
     }
     
@@ -255,7 +255,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, UIAutomationTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, UIAutomationTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.UIAUTOMATION);
     }
     
@@ -267,7 +267,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, XCTestTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, XCTestTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.XCTEST);
     }
 
@@ -279,7 +279,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, AppiumJavaTestNGTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, AppiumJavaTestNGTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_JAVA_TESTNG);
     }
 
@@ -291,7 +291,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    public Upload uploadTest(Project project, AppiumJavaJUnitTest test) throws IOException, AWSDeviceFarmException {
+    public Upload uploadTest(Project project, AppiumJavaJUnitTest test) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(project, test.getTests(), AWSDeviceFarmUploadType.APPIUM_JAVA_JUNIT);
     }
 
@@ -304,7 +304,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    private Upload upload(Project project, String artifact, AWSDeviceFarmUploadType uploadType) throws IOException, AWSDeviceFarmException {
+    private Upload upload(Project project, String artifact, AWSDeviceFarmUploadType uploadType) throws InterruptedException, IOException, AWSDeviceFarmException {
         if (artifact == null || artifact.isEmpty()) {
             throw new AWSDeviceFarmException("Must have an artifact path.");
         }
@@ -326,7 +326,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    private Upload upload(File file, Project project, AWSDeviceFarmUploadType uploadType) throws IOException, AWSDeviceFarmException {
+    private Upload upload(File file, Project project, AWSDeviceFarmUploadType uploadType) throws InterruptedException, IOException, AWSDeviceFarmException {
         return upload(file, project, uploadType, true);
     }
 
@@ -340,7 +340,7 @@ public class AWSDeviceFarm {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    private Upload upload(File file, Project project, AWSDeviceFarmUploadType uploadType, Boolean synchronous) throws IOException, AWSDeviceFarmException {
+    private Upload upload(File file, Project project, AWSDeviceFarmUploadType uploadType, Boolean synchronous) throws InterruptedException, IOException, AWSDeviceFarmException {
         CreateUploadRequest appUploadRequest = new CreateUploadRequest()
                 .withName(file.getName())
                 .withProjectArn(project.getArn())
@@ -369,6 +369,7 @@ public class AWSDeviceFarm {
                 String status = describeUploadResult.getUpload().getStatus();
 
                 if ("SUCCEEDED".equalsIgnoreCase(status)) {
+                    writeToLog(String.format("Upload %s succeeded", file.getName()));
                     break;
                 }
                 else if ("FAILED".equalsIgnoreCase(status)) {
@@ -380,7 +381,8 @@ public class AWSDeviceFarm {
                         Thread.sleep(5000);
                     }
                     catch (InterruptedException e) {
-                        break;
+                        writeToLog(String.format("Thread interrupted while waiting for the upload to complete"));
+                        throw e;
                     }
                 }
             }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -382,11 +382,9 @@ public class AWSDeviceFarmRecorder extends Recorder {
         Map<String, FilePath> suites = new HashMap<String, FilePath>();
         String runArn = run.getRun().getArn();
         String components[] = runArn.split(":");
-        // constructing job arn for each job 
+        // constructing job ARN for each job using the run ARN
         components[5] = "job";
-        for(String jobArn:jobs.keySet())
-        {
-            writeToLog(String.format("Jobarn: %s", jobArn));
+        for(String jobArn:jobs.keySet()) {
             components[6] = jobArn;
             String fullJobArn = StringUtils.join(components,":");
             ListSuitesResult result = adf.listSuites(fullJobArn);

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -26,6 +26,7 @@ import hudson.util.FormValidation;
 import hudson.util.IOUtils;
 import hudson.util.ListBoxModel;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.plugins.awsdevicefarm.test.*;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
@@ -56,6 +57,10 @@ public class AWSDeviceFarmRecorder extends Recorder {
     public String eventCount;
     public String eventThrottle;
     public String seed;
+
+    // Built-in Explorer
+    public String username;
+    public String password;
 
     // Appium Java JUnit
     public String appiumJavaJUnitTest;
@@ -94,6 +99,8 @@ public class AWSDeviceFarmRecorder extends Recorder {
      * @param eventCount The number of fuzz events to run.
      * @param eventThrottle The the fuzz event throttle count.
      * @param seed The initial seed of fuzz events.
+     * @param username username to use if explorer encounters a login form.
+     * @param password password to use if explorer encounters a login form.
      * @param appiumJavaJUnitTest
      * @param appiumJavaTestNGTest
      * @param calabashFeatures The path to the Calabash tests to be run.
@@ -116,6 +123,8 @@ public class AWSDeviceFarmRecorder extends Recorder {
                                  String eventCount,
                                  String eventThrottle,
                                  String seed,
+                                 String username,
+                                 String password,
                                  String appiumJavaJUnitTest,
                                  String appiumJavaTestNGTest,
                                  String calabashFeatures,
@@ -135,6 +144,8 @@ public class AWSDeviceFarmRecorder extends Recorder {
         this.eventCount = eventCount;
         this.eventThrottle = eventThrottle;
         this.seed = seed;
+        this.username = username;
+        this.password = password;
         this.appiumJavaJUnitTest = appiumJavaJUnitTest;
         this.appiumJavaTestNGTest = appiumJavaTestNGTest;
         this.calabashFeatures = calabashFeatures;
@@ -325,7 +336,6 @@ public class AWSDeviceFarmRecorder extends Recorder {
                         artifactFilePath.write().write(IOUtils.toByteArray(url.openStream()));
                     }
                 }
-
                 writeToLog(String.format("Results archive saved in %s", artifactsDir.getName()));
             }
 
@@ -370,14 +380,22 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
     private Map<String, FilePath> getSuites(AWSDeviceFarm adf, ScheduleRunResult run, Map<String, FilePath> jobs) throws IOException, InterruptedException {
         Map<String, FilePath> suites = new HashMap<String, FilePath>();
-        ListSuitesResult result = adf.listSuites(run.getRun().getArn());
-        for (Suite suite : result.getSuites()) {
-            String arn = suite.getArn().split(":")[6];
-            String jobArn = arn.substring(0, arn.lastIndexOf("/"));
-            suites.put(arn, new FilePath(jobs.get(jobArn), suite.getName()));
-            suites.get(arn).mkdirs();
+        String runArn = run.getRun().getArn();
+        String components[] = runArn.split(":");
+        // constructing job arn for each job 
+        components[5] = "job";
+        for(String jobArn:jobs.keySet())
+        {
+            writeToLog(String.format("Jobarn: %s", jobArn));
+            components[6] = jobArn;
+            String fullJobArn = StringUtils.join(components,":");
+            ListSuitesResult result = adf.listSuites(fullJobArn);
+            for (Suite suite : result.getSuites()) {
+                String arn = suite.getArn().split(":")[6];
+                suites.put(arn, new FilePath(jobs.get(jobArn), suite.getName()));
+                suites.get(arn).mkdirs();
+            }
         }
-
         return suites;
     }
 
@@ -389,7 +407,6 @@ public class AWSDeviceFarmRecorder extends Recorder {
             jobs.put(arn, new FilePath(resultsDir, job.getName()));
             jobs.get(arn).mkdirs();
         }
-
         return jobs;
     }
 
@@ -402,7 +419,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    private ScheduleRunTest getScheduleRunTest(EnvVars env, AWSDeviceFarm adf, Project project) throws IOException, AWSDeviceFarmException {
+    private ScheduleRunTest getScheduleRunTest(EnvVars env, AWSDeviceFarm adf, Project project) throws InterruptedException, IOException, AWSDeviceFarmException {
         ScheduleRunTest testToSchedule = null;
         TestType testType = stringToTestType(testToRun);
 
@@ -420,6 +437,23 @@ public class AWSDeviceFarmRecorder extends Recorder {
 
                 if (seed != null && !seed.isEmpty()) {
                     parameters.put("seed", seed);
+                }
+
+                testToSchedule = new ScheduleRunTest()
+                        .withType(testType)
+                        .withParameters(parameters);
+                break;
+            }
+
+            case BUILTIN_EXPLORER: {
+                Map<String, String> parameters = new HashMap<String, String>();
+
+                if (username != null && !username.isEmpty()) {
+                    parameters.put("username", username);
+                }
+
+                if (password != null && !password.isEmpty()) {
+                    parameters.put("password", password);
                 }
 
                 testToSchedule = new ScheduleRunTest()
@@ -595,6 +629,10 @@ public class AWSDeviceFarmRecorder extends Recorder {
                     }
                 }
 
+                break;
+            }
+            
+            case BUILTIN_EXPLORER : {
                 break;
             }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -55,15 +55,10 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
             GetRunResult latestRunResult = adf.describeRun(runResult.getRun().getArn());
             Run run = latestRunResult.getRun();
             result = new AWSDeviceFarmTestResult(owner, run);
-
-            if (!result.isCompleted()) {
-                writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
-            }
-            else {
-                writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
+            writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
+            if (result.isCompleted()) {
                 break;
             }
-
             try {
                 Thread.sleep(DefaultUpdateInterval);
             }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -5,6 +5,7 @@ import java.io.PrintStream;
 import com.amazonaws.services.devicefarm.model.GetRunResult;
 import com.amazonaws.services.devicefarm.model.Run;
 import com.amazonaws.services.devicefarm.model.ScheduleRunResult;
+
 import hudson.model.AbstractBuild;
 import hudson.model.Result;
 import hudson.tasks.test.AbstractTestResultAction;
@@ -49,7 +50,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
      * to populate/inform the UI of test results/progress.
      * @param runResult
      */
-    public void waitForRunCompletion(AWSDeviceFarm adf, ScheduleRunResult runResult) {
+    public void waitForRunCompletion(AWSDeviceFarm adf, ScheduleRunResult runResult) throws InterruptedException {
         while (true) {
             GetRunResult latestRunResult = adf.describeRun(runResult.getRun().getArn());
             Run run = latestRunResult.getRun();
@@ -59,6 +60,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
                 writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
             }
             else {
+                writeToLog(String.format("Run %s status %s", run.getName(), run.getStatus()));
                 break;
             }
 
@@ -66,7 +68,8 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
                 Thread.sleep(DefaultUpdateInterval);
             }
             catch(InterruptedException ex) {
-                break;
+                writeToLog(String.format("Thread interrupted while waiting for the Run to complete"));
+                throw ex;
             }
         }
     }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/BuiltinExplorerTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/BuiltinExplorerTest.java
@@ -1,0 +1,79 @@
+package org.jenkinsci.plugins.awsdevicefarm.test;
+
+/**
+ * POJO class for a built-in Explorer test.
+ */
+public class BuiltinExplorerTest {
+
+    private final String username;
+    private final String password;
+
+    /**
+     * Static builder class.
+     */
+    public static class Builder {
+        private String username;
+        private String password;
+
+        /**
+         * username setter
+         * @param username username to use if explorer encounters a login form.
+         * @return the Builder object.
+         */
+        public Builder withUsername(String username) {
+            this.username = username;
+            return this;
+        }
+
+        /**
+         * password setter password to use if explorer encounters a login form.
+         * @param password the Builder object.
+         * @return
+         */
+        public Builder withPassword(String password) {
+            this.password = password;
+            return this;
+        }
+
+        /**
+         * Builder method.
+         * @return The new POJO.
+         */
+        public BuiltinExplorerTest build() {
+            return new BuiltinExplorerTest(this);
+        }
+
+    }
+
+    /**
+     * POJO constructor with builder.
+     * @param builder The builder to use.
+     */
+    private BuiltinExplorerTest(Builder builder) {
+        this.username = builder.username;
+        this.password = builder.password;
+    }
+
+    public BuiltinExplorerTest(String username, String password) {
+        super();
+        this.username = username;
+        this.password = password;
+    }
+
+    /**
+     * username getter
+     * @return username to use in the login form
+     */
+    public String getUsername() {
+        return username;
+    }
+
+    /**
+     * password getter
+     * @return password to use in the login form
+     */
+    public String getPassword() {
+        return password;
+    }
+
+}

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -23,6 +23,17 @@
   </f:entry>
 
   <f:section title="Choose test to run">
+    <f:radioBlock name="testToRun" value="BUILTIN_EXPLORER" checked="${instance.isTestType('BUILTIN_EXPLORER')}" title="Android Built-in Explorer" inline="true">
+      <f:nested>
+        <f:entry title="Username" field="username" description="A username to use if the Explorer encounters a login form. If not supplied, no username will be inserted.">
+          <f:textbox/>
+        </f:entry>
+        <f:entry title="Password" field="password" description="A password to use if the Explorer encounters a login form. If not supplied, no password will be inserted.">
+          <f:password/>
+        </f:entry>
+      </f:nested>
+    </f:radioBlock>
+    
     <f:radioBlock name="testToRun" value="BUILTIN_FUZZ" checked="${instance.isTestType('BUILTIN_FUZZ')}" title="Built-in Fuzz" inline="true">
       <f:nested>
         <f:entry title="Event Count" field="eventCount" description="[Optional] Number of fuzz events.">

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/help-password.html
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/help-password.html
@@ -1,7 +1,0 @@
-<div>
-  [Optional] Value to be used in the password field when the AWS Device Farm AppExplorer encounters a sign-in form. <br />
-  <u>Default:</u> <br />
-  <br />
-  <u>Examples:</u> <br />
-  test_password_123* <br />
-</div>


### PR DESCRIPTION
When ever we upload an app, Jenkins should wait till the upload status changes to succeed. However while waiting if for some reason , the thread was interrupted, we were breaking out and continuing with the execution. Since Schedule run expected the upload status as succeed, it was throwing exception that upload is not processed.

Similar issue was while waiting for the result from the run handler.
I have fixed both.

 