### PR TITLE
Expand environment variables in calabash tags

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -561,7 +561,7 @@ public class AWSDeviceFarmRecorder extends Recorder {
             case CALABASH: {
                 CalabashTest test = new CalabashTest.Builder()
                         .withFeatures(env.expand(calabashFeatures))
-                        .withTags(calabashTags)
+                        .withTags(env.expand(calabashTags))
                         .withProfile(calabashProfile)
                         .build();
 


### PR DESCRIPTION
At the moment build parameters will not resolve properly in the "Tags" field. We need this so that we can run separate Jenkins jobs for each tag from our Pipeline job.

<img width="812" alt="screen shot 2016-12-16 at 5 58 45 pm" src="https://cloud.githubusercontent.com/assets/2293064/21281268/58d85eb0-c3b9-11e6-96cb-4670f0745635.png">
