### PR TITLE
enable support for roleArn authentication

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -1,11 +1,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
     <f:section title="AWS Device Farm">
-        <!--
         <f:entry title="IAM Role ARN" field="roleArn" description="AWS IAM Role ARN.">
             <f:textbox />
         </f:entry>
-        -->
         <f:entry title="AKID" field="akid" description="AWS Access Key ID.">
             <f:textbox />
         </f:entry>


### PR DESCRIPTION
Existing Issues:
https://github.com/awslabs/aws-device-farm-jenkins-plugin/issues/42
https://github.com/awslabs/aws-device-farm-jenkins-plugin/issues/33

@appwiz @ahawker 
I uncommented the existing code for specifying a roleArn and after some testing I noticed that the roleArn authentication was expiring every 15mins. I looked around the [AWS documentation](http://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_temp_request.html) and it looks like the the STS API AssumeRole expires after a certain period of time. I went ahead and created a ScheduleExecutorService that runs every 14mins to re-authenticate using the existing implementation of the STSAssumeRoleSessionCredentialsProvider. Although the maximum AWS Device Farm limit is 60 minutes per test this PR should account for situations when the time limit is increased upon customer request or if/when the time caps get removed by AWS.

What do you folks think? Feel free to tear this PR apart. :) 