### PR TITLE
Add support for using the java proxy settings for uploading to device farm

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -372,7 +372,7 @@ public class AWSDeviceFarm {
                 .withType(uploadType.toString());
         Upload upload = api.createUpload(appUploadRequest).getUpload();
 
-        CloseableHttpClient httpClient = HttpClients.createDefault();
+        CloseableHttpClient httpClient = HttpClients.createSystem();
         HttpPut httpPut = new HttpPut(upload.getUrl());
         httpPut.setHeader("Content-Type", upload.getContentType());
 


### PR DESCRIPTION
Current the plugin does not support uploading to the device farm via a proxy (see issue #31)

This PR will enable that by changing how the httpClient object is created.

Using createSystem() instead of createDefault() will create an httpClient object
that is configured to use the java proxy settings instead of ignoring them.