### PR TITLE
Fix -Device Pool not been listed for one project account

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -4,7 +4,7 @@
   <f:validateButton title="refresh" method="refresh" progress="Checking..." inline="true" />
 
   <f:entry title="Project" field="projectName" description="[Required] Select your AWS Device Farm project.">
-    <f:select style="width:100%; padding-right:5px; margin-right:5px" inline="true" />
+    <f:select default="Select your project" style="width:100%; padding-right:5px; margin-right:5px" inline="true" />
   </f:entry>
 
   <f:entry title="Device Pool" field="devicePoolName" description="[Required] Select your AWS Device Farm device pool.">


### PR DESCRIPTION
Setting default value (placeholder) for Project select in jelly avoids null/blank project name to doFillDevicePoolNameItems.