### PR TITLE
 modified code to check for enviroment variables on filters

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -925,7 +925,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                 CalabashTest test = new CalabashTest.Builder()
                         .withFeatures(env.expand(calabashFeatures))
                         .withTags(env.expand(calabashTags))
-                        .withProfile(calabashProfile)
+                        .withProfile(env.expand(calabashProfile))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -947,7 +947,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case INSTRUMENTATION: {
                 InstrumentationTest test = new InstrumentationTest.Builder()
                         .withArtifact(env.expand(junitArtifact))
-                        .withFilter(junitFilter)
+                        .withFilter(env.expand(junitFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -963,7 +963,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case UIAUTOMATOR: {
                 UIAutomatorTest test = new UIAutomatorTest.Builder()
                         .withTests(env.expand(uiautomatorArtifact))
-                        .withFilter(uiautomatorFilter)
+                        .withFilter(env.expand(uiautomatorFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -993,7 +993,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             case XCTEST: {
                 XCTestTest test = new XCTestTest.Builder()
                         .withTests(xctestArtifact)
-                        .withFilter(xctestFilter)
+                        .withFilter(env.expand(xctestFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);
@@ -1006,9 +1006,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             }
 
             case XCTEST_UI: {
+
                 XCTestUITest test = new XCTestUITest.Builder()
                         .withTests(xctestUiArtifact)
-                        .withFilter(xctestUiFilter)
+                        .withFilter(env.expand(xctestUiFilter))
                         .build();
 
                 Upload upload = adf.uploadTest(project, test);


### PR DESCRIPTION
## Issue: 
  Currently, the Jenkins plugin for Device Farm does not accept environment variable for filter values. This change allows this and also accepts default string values. 

Tested here
**environment var**: https://us-west-2.console.aws.amazon.com/devicefarm/home#/projects/8122b260-5eec-43e5-ae03-a0bf1c5f2ff7/runs/9ad7844f-647f-4880-9d2f-3589176ce448

**Normal string values**: https://us-west-2.console.aws.amazon.com/devicefarm/home#/projects/8122b260-5eec-43e5-ae03-a0bf1c5f2ff7/runs/140ab823-56e2-4eac-bab8-a09da705001b

**WARNING**: I have only tested this with XCUI tests however I thought the changes could be applicable to the other frameworks as well. I did not test those. 
