### PR TITLE
[JENKINS-53664] - Stop serializing Logger in the TestResult action

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -647,7 +647,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             }
 
             // Attach AWS Device Farm action to poll periodically and update results UI.
-            AWSDeviceFarmTestResultAction action = new AWSDeviceFarmTestResultAction(build, null, log);
+            AWSDeviceFarmTestResultAction action = new AWSDeviceFarmTestResultAction(build, null);
             build.addAction(action);
 
             // Wait for test result to complete will updating status periodically.

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -36,7 +36,6 @@ import java.io.PrintStream;
 public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSDeviceFarmTestResultAction> implements StaplerProxy {
 
     private static final int DefaultUpdateInterval = 30 * 1000;
-    private PrintStream log;
     private AWSDeviceFarmTestResult result;
 
     public AWSDeviceFarmTestResultAction(AbstractBuild<?, ?> owner, AWSDeviceFarmTestResult result) {
@@ -44,10 +43,9 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
         this.result = result;
     }
 
-    public AWSDeviceFarmTestResultAction(hudson.model.Run<?, ?> owner, AWSDeviceFarmTestResult result, PrintStream log) {
+    public AWSDeviceFarmTestResultAction(hudson.model.Run<?, ?> owner, AWSDeviceFarmTestResult result) {
         super();
         onAttached(owner);
-        this.log = log;
         this.result = result;
     }
 


### PR DESCRIPTION
Fixes regression of JEP-200 compatibility.

Re-adds changes from commit 4070a743dc47574572d352a15b3febce4f6ed5ed that were lost in a merge.

This fixes build history getting lost in the Jenkins UI, and cleanup of archiving failing which led to the disk filling up.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
