### PR TITLE
Fix build findbugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ target/*
 .settings/*
 .classpath
 .project
+.factorypath
 
 # Vagrant
 .vagrant

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -299,7 +299,7 @@ public class AWSDeviceFarm {
     /**
      * Helper function to detect a default testspec file for frameworks that cannot use it.
      *
-     * @param upload Testspec
+     * @param testSpec the testspec file to check
      *
      * @return true if it is a default spec file.
      * @throws AWSDeviceFarmException

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -588,7 +588,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
 
             // Upload test content.
             writeToLog(log, "Getting test to schedule.");
-            ScheduleRunTest testToSchedule = getScheduleRunTest(env, adf, project);
+            ScheduleRunTest testToSchedule = getScheduleRunTest(env, adf, project, log);
 
             // by default videoCapture is always enabled
             Boolean videoCapture = true;
@@ -813,7 +813,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @throws IOException
      * @throws AWSDeviceFarmException
      */
-    private ScheduleRunTest getScheduleRunTest(EnvVars env, AWSDeviceFarm adf, Project project) throws InterruptedException, IOException, AWSDeviceFarmException {
+    private ScheduleRunTest getScheduleRunTest(EnvVars env, AWSDeviceFarm adf, Project project, PrintStream log) throws InterruptedException, IOException, AWSDeviceFarmException {
         ScheduleRunTest testToSchedule = null;
         TestType testType = stringToTestType(testToRun);
 
@@ -1100,6 +1100,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                         .withFilter(test.getFilter())
                         .withTestPackageArn(upload.getArn());
                 break;
+            }
+
+            default: {
+                writeToLog(log, String.format("Cannot schedule unknown test type '%s'", testType));
             }
 
         }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -435,7 +435,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     /**
      * Test if the environment selected by Customer is 'Standard' (for marking the radio button).
      *
-     * @param testTypeName
+     * @param environmentToRun
      *            The String representation of the environment.
      * @return Whether or not the test type string matches.
      */
@@ -486,7 +486,6 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @param build    The build to follow.
      * @param launcher The launcher.
      * @param listener The build launcher.
-     * @return Whether or not the post-build action succeeded.
      * @throws IOException
      * @throws InterruptedException
      */

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
@@ -176,8 +176,8 @@ public class AWSDeviceFarmTestResult extends TestResult {
     /**
      * Return a list of up to (n) of the most recent/previous AWS Device Farm results.
      *
-     * @param n
-     * @return
+     * @param n number of results requested
+     * @return list of previous results
      */
     @SuppressWarnings("unused")
     protected List<AWSDeviceFarmTestResult> getPreviousResults(int n) {
@@ -190,7 +190,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
      * Return a list of all AWS Device Farm results from all builds previous to the build that this result is tied to.
      * The list is return in increasing, sequential order.
      *
-     * @return
+     * @return list of previous results
      */
     @SuppressWarnings("unused")
     protected List<AWSDeviceFarmTestResult> getPreviousResults() {
@@ -231,7 +231,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
      * Return true if this result is "completed". A completed result is a result
      * who is both marked as completed and has had its results archived for download.
      *
-     * @return
+     * @return true if completed
      */
     public Boolean isCompleted() {
         return status != null
@@ -241,7 +241,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
     /**
      * Return a Jenkins build result which matches the result status from AWS Device Farm.
      *
-     * @return
+     * @return Jenkins build result
      */
     public Result getBuildResult(Boolean ignoreRunError) {
         if (ignoreRunError != null && ignoreRunError && ExecutionResult.ERRORED.equals(result)) {
@@ -268,8 +268,8 @@ public class AWSDeviceFarmTestResult extends TestResult {
      * test result the ID's match, otherwise scan our previous runs looking for a matching result.
      * If no match is found, return null.
      *
-     * @param id
-     * @return
+     * @param id test result ID
+     * @return the AWS Device Farm test result for the given id
      */
     public TestResult findCorrespondingResult(String id) {
         if (id == null || getId().equalsIgnoreCase(id)) {
@@ -292,9 +292,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return number of test passes in this result.
-     *
-     * @return
+     * @return number of test passes in this result
      */
     @Override
     public int getPassCount() {
@@ -302,18 +300,14 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return number of test warnings in this result.
-     *
-     * @return
+     * @return number of test warnings in this result
      */
     public int getWarnCount() {
         return warnCount;
     }
 
     /**
-     * Return number of test failures in this result.
-     *
-     * @return
+     * @return number of test failures in this result
      */
     @Override
     public int getFailCount() {
@@ -321,27 +315,21 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return number of test errors in this result.
-     *
-     * @return
+     * @return number of test errors in this result
      */
     public int getStopCount() {
         return stopCount;
     }
 
     /**
-     * Return number of test errors in this result.
-     *
-     * @return
+     * @return number of test errors in this result
      */
     public int getErrorCount() {
         return errorCount;
     }
 
     /**
-     * Return number of test errors in this result.
-     *
-     * @return
+     * @return number of test skipped in this result
      */
     @Override
     public int getSkipCount() {
@@ -349,9 +337,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return total number of tests run in this result.
-     *
-     * @return
+     * @return total number of tests run in this result
      */
     @Override
     public int getTotalCount() {
@@ -359,9 +345,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return total number of device minutes used by the run which generated this result.
-     *
-     * @return
+     * @return total number of device minutes used by the run which generated this result
      */
     @Override
     public float getDuration() {
@@ -369,9 +353,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
     }
 
     /**
-     * Return true if there are no tests for this result, false otherwise.
-     *
-     * @return
+     * @return true if there are no tests for this result, false otherwise
      */
     public Boolean isEmpty() {
         return getTotalCount() == 0;

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResultAction.java
@@ -60,9 +60,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
     }
 
     /**
-     * Returns the Jenkins result which matches the result of this AWS Device Farm run.
-     *
-     * @return
+     * @return the Jenkins result which matches the result of this AWS Device Farm run
      */
     public Result getBuildResult(Boolean ignoreRunError) {
         return getResult().getBuildResult(ignoreRunError);
@@ -99,9 +97,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
     }
 
     /**
-     * Returns the most recent AWS Device Farm test action from the previous build.
-     *
-     * @return
+     * @return the most recent AWS Device Farm test action from the previous build
      */
     @Override
     public AWSDeviceFarmTestResultAction getPreviousResult() {
@@ -113,9 +109,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
     }
 
     /**
-     * Returns a snapshot of the current results for this AWS Device Farm run.
-     *
-     * @return
+     * @return a snapshot of the current results for this AWS Device Farm run
      */
     @Override
     public AWSDeviceFarmTestResult getResult() {
@@ -123,18 +117,14 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
     }
 
     /**
-     * Returns a snapshot of the current results for this AWS Device Farm run.
-     *
-     * @return
+     * @return a snapshot of the current results for this AWS Device Farm run
      */
     public AWSDeviceFarmTestResult getTarget() {
         return getResult();
     }
 
     /**
-     * Returns the number of failed tests for this AWS Device Farm run.
-     *
-     * @return
+     * @return the number of failed tests for this AWS Device Farm run
      */
     @Override
     public int getFailCount() {
@@ -147,9 +137,7 @@ public class AWSDeviceFarmTestResultAction extends AbstractTestResultAction<AWSD
     }
 
     /**
-     * Returns the total number of tests for this AWS Device Farm run.
-     *
-     * @return
+     * @return the total number of tests for this AWS Device Farm run
      */
     @Override
     public int getTotalCount() {

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/BuiltinExplorerTest.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/test/BuiltinExplorerTest.java
@@ -44,7 +44,7 @@ public class BuiltinExplorerTest {
          * password setter password to use if explorer encounters a login form.
          *
          * @param password the Builder object.
-         * @return
+         * @return the Builder object.
          */
         public Builder withPassword(String password) {
             this.password = password;


### PR DESCRIPTION
Fixes FindBugs and JavaDoc warnings.

Cleans up the build output.

I extracted the FindBugs fix from PR #90 so that it can be merged independently.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
