### PR TITLE
Fix file descriptor leak when archiving test results

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -54,7 +54,6 @@ import hudson.tasks.BuildStepMonitor;
 import hudson.tasks.Publisher;
 import hudson.tasks.Recorder;
 import hudson.util.FormValidation;
-import hudson.util.IOUtils;
 import hudson.util.ListBoxModel;
 import net.sf.json.JSONObject;
 import javax.annotation.Nonnull;
@@ -676,9 +675,11 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                         String testArn = arn.substring(0, arn.lastIndexOf("/"));
                         String id = arn.substring(arn.lastIndexOf("/") + 1);
                         String extension = artifact.getExtension().replaceFirst("^\\.", "");
-                        FilePath artifactFilePath = new FilePath(tests.get(testArn), String.format("%s-%s.%s", artifact.getName(), id, extension));
-                        URL url = new URL(artifact.getUrl());
-                        artifactFilePath.write().write(IOUtils.toByteArray(url.openStream()));
+
+                        // Copy remote file to local path for archiving
+                        FilePath localArtifact = new FilePath(tests.get(testArn), String.format("%s-%s.%s", artifact.getName(), id, extension));
+                        URL artifactUrl = new URL(artifact.getUrl());
+                        localArtifact.copyFrom(artifactUrl);
                     }
                 }
                 writeToLog(log, String.format("Results archive saved in %s", artifactsDir.getName()));


### PR DESCRIPTION
The process of copying the remote test results files to Jenkins for
archiving leaves a file stream open. This causes a build-up of open file
descriptors on the Jenkins Master which will eventually crash a unix
system depending on ulimit 'open files' setting.

This fix replaces the inline copying of files with the build-in
FilePath.copyFrom() method which closes the streams correctly.

This patch is running in our Production Jenkins currently and solved our
issue with build-up of open files.

To illustrate, previous we saw output like this on the Jenkins Master:
```
bash-4.2$ lsof 2>/dev/null|sed 's#.*/var#/var#'|grep '/var/lib/jenkins/jobs'|head
/var/lib/jenkins/jobs/dispatcher/jobs/heredriver-automation/jobs/AWS_testing_jobs/jobs/regression_android_tests/builds/.57/archive/AWS Device Farm Results/Google Pixel 128 GB-7.1.2/Street Hailing E2E/tests.e2e_tests.StreetHailingTest.streetHailingTest/Appium Java Output-00001.txt (deleted)
/var/lib/jenkins/jobs/dispatcher/jobs/heredriver-automation/jobs/AWS_testing_jobs/jobs/regression_android_tests/builds/.55/archive/AWS Device Farm Results/Google Pixel 128 GB-7.1.2/Empty Destination Manual Ride Request test/tests.ride_request_tests.EmptyDestinationManualRideRequestTest.emptyDestinationManualRideRequestTest/Appium Java XML Output-00001.xml (deleted)
/var/lib/jenkins/jobs/dispatcher/jobs/heredriver-automation/jobs/AWS_testing_jobs/jobs/regression_android_tests/builds/.57/archive/AWS Device Farm Results/Google Pixel 128 GB-7.1.2/Teardown Suite/Teardown Test/Logcat-00000.logcat (deleted)
/var/lib/jenkins/jobs/dispatcher/jobs/heredriver-automation/jobs/AWS_testing_jobs/jobs/regression_android_tests/builds/.57/archive/AWS Device Farm Results/Google Pixel 128 GB-7.1.2/Login tests/tests.LoginTest.loginPositiveFlow/TCP dump log-00006.txt (deleted)
/var/lib/jenkins/jobs/dispatcher/jobs/heredriver-automation/jobs/AWS_testing_jobs/jobs/regression_android_tests/builds/.60/archive/AWS Device Farm Results/Google Pixel 128 GB-7.1.2/Reject Manual Ride Request test/tests.ride_request_tests.RejectManualRideRequestTest.rejectManualTripTest/Logcat-00004.logcat (deleted)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
