### PR TITLE
Fixing ignoreRunError bug

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
@@ -249,8 +249,6 @@ public class AWSDeviceFarmTestResult extends TestResult {
                 result = ExecutionResult.SKIPPED;
             } else if (stopCount > 0) {
                 result = ExecutionResult.STOPPED;
-            } else if (errorCount > 0) {
-                result = ExecutionResult.ERRORED;
             } else if (failCount > 0) {
                 result = ExecutionResult.FAILED;
             } else if (warnCount > 0) {


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-device-farm-jenkins-plugin/issues/43

*Description of changes:*

Fixes buggy ignoreRunError being marked as FAILED when Device Farm errors on the run.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
