### PR TITLE
Customizable proxy by parameter in the global configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -711,6 +711,7 @@ public class AWSDeviceFarm {
         CloseableHttpClient httpClient = HttpClients.createSystem();
 
         if (proxyConfig.getActive()) {
+            writeToLog(String.format("Using proxy %s to upload", proxyConfig.getHttpProxyFQDN()));
             httpClient = proxyConfig.httpClientWithProxy();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -109,8 +109,8 @@ public class AWSDeviceFarm {
      *
      * @param roleArn Role ARN to use for authentication.
      */
-    public AWSDeviceFarm(String roleArn) {
-        this(null, roleArn);
+    public AWSDeviceFarm(String roleArn, AWSDeviceFarmProxy proxyConfig) {
+        this(null, roleArn, proxyConfig);
     }
 
     /**
@@ -118,8 +118,8 @@ public class AWSDeviceFarm {
      *
      * @param creds AWSCredentials to use for authentication.
      */
-    public AWSDeviceFarm(AWSCredentials creds) {
-        this(creds, null);
+    public AWSDeviceFarm(AWSCredentials creds, AWSDeviceFarmProxy proxyConfig) {
+        this(creds, null, proxyConfig);
     }
 
     /**
@@ -128,8 +128,9 @@ public class AWSDeviceFarm {
      *
      * @param creds   AWSCredentials creds to use for authentication.
      * @param roleArn Role ARN to use for authentication.
+     * @param proxyConfig Proxy Custom Config for communicate with external services.
      */
-    private AWSDeviceFarm(AWSCredentials creds, String roleArn) {
+    private AWSDeviceFarm(AWSCredentials creds, String roleArn, AWSDeviceFarmProxy proxyConfig) {
         if (roleArn != null) {
             STSAssumeRoleSessionCredentialsProvider sts = new STSAssumeRoleSessionCredentialsProvider
                     .Builder(roleArn, RandomStringUtils.randomAlphanumeric(8))
@@ -139,6 +140,15 @@ public class AWSDeviceFarm {
         }
 
         ClientConfiguration clientConfiguration = new ClientConfiguration().withUserAgent("AWS Device Farm - Jenkins v1.0");
+
+        if (!proxyConfig.getHttpProxyFQDN().isEmpty()) {
+            clientConfiguration.setProxyHost(proxyConfig.getHttpProxyFQDN());
+            clientConfiguration.setProxyPort(proxyConfig.getHttpProxyPort());
+            clientConfiguration.setProxyUsername(proxyConfig.getHttpProxyUser());
+            clientConfiguration.setProxyPassword(proxyConfig.getHttpProxyPass());
+            clientConfiguration.setDisableSocketProxy(true);
+        }
+
         api = new AWSDeviceFarmClient(creds, clientConfiguration);
         api.setServiceNameIntern("devicefarm");
     }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -141,7 +141,7 @@ public class AWSDeviceFarm {
 
         ClientConfiguration clientConfiguration = new ClientConfiguration().withUserAgent("AWS Device Farm - Jenkins v1.0");
 
-        if (!proxyConfig.getHttpProxyFQDN().isEmpty()) {
+        if (proxyConfig != null && !proxyConfig.getHttpProxyFQDN().isEmpty()) {
             clientConfiguration.setProxyHost(proxyConfig.getHttpProxyFQDN());
             clientConfiguration.setProxyPort(proxyConfig.getHttpProxyPort());
             clientConfiguration.setProxyUsername(proxyConfig.getHttpProxyUser());

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -711,7 +711,6 @@ public class AWSDeviceFarm {
         CloseableHttpClient httpClient = HttpClients.createSystem();
 
         if (proxyConfig.getActive()) {
-            writeToLog(String.format("Using proxy %s to upload", proxyConfig.getHttpProxyFQDN()));
             httpClient = proxyConfig.httpClientWithProxy();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarm.java
@@ -717,7 +717,7 @@ public class AWSDeviceFarm {
 
         CloseableHttpClient httpClient = HttpClients.createSystem();
 
-        if (!proxyConfig.getHttpProxyFQDN().isEmpty()) {
+        if (proxyConfig != null && !proxyConfig.getHttpProxyFQDN().isEmpty()) {
             CredentialsProvider credentialProvider = new BasicCredentialsProvider();
             credentialProvider.setCredentials(
                 new AuthScope(proxyConfig.getHttpProxyFQDN(), proxyConfig.getHttpProxyPort()),

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
@@ -17,10 +17,10 @@ public class AWSDeviceFarmProxy {
     private boolean active = false;
 
     AWSDeviceFarmProxy(String httpProxyFQDN, int httpProxyPort, String httpProxyUser, String httpProxyPass) {
-        this.setHttpProxyFQDN(httpProxyFQDN);
+        this.setHttpProxyFQDN(httpProxyFQDN != null ? httpProxyFQDN : "");
         this.setHttpProxyPort(httpProxyPort);
-        this.setHttpProxyUser(httpProxyUser);
-        this.setHttpProxyPass(httpProxyPass);
+        this.setHttpProxyUser(httpProxyUser != null ? httpProxyUser : "");
+        this.setHttpProxyPass(httpProxyPass != null ? httpProxyPass : "");
     }
 
     public void setHttpProxyFQDN(String value) {

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
@@ -25,7 +25,9 @@ public class AWSDeviceFarmProxy {
 
     public void setHttpProxyFQDN(String value) {
         this.httpProxyFQDN = value;
-        this.setActive(true);
+        if (!value.isEmpty()) {
+            this.setActive(true);
+        }
     }
 
     public void setActive(boolean value) {

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
@@ -1,0 +1,47 @@
+package org.jenkinsci.plugins.awsdevicefarm;
+
+public class AWSDeviceFarmProxy {
+    private String httpProxyFQDN;
+    private int httpProxyPort;
+    private String httpProxyUser;
+    private String httpProxyPass;
+
+    AWSDeviceFarmProxy(String httpProxyFQDN, int httpProxyPort, String httpProxyUser, String httpProxyPass) {
+        this.setHttpProxyFQDN(httpProxyFQDN);
+        this.setHttpProxyPort(httpProxyPort);
+        this.setHttpProxyUser(httpProxyUser);
+        this.setHttpProxyPass(httpProxyPass);
+    }
+
+    public void setHttpProxyFQDN(String value) {
+        this.httpProxyFQDN = value;
+    }
+
+    public void setHttpProxyPort(int value) {
+        this.httpProxyPort = value;
+    }
+
+    public void setHttpProxyUser(String value) {
+        this.httpProxyUser = value;
+    }
+
+    public void setHttpProxyPass(String value) {
+        this.httpProxyPass = value;
+    }
+
+    public String getHttpProxyFQDN() {
+        return this.httpProxyFQDN;
+    }
+
+    public int getHttpProxyPort() {
+        return this.httpProxyPort;
+    }
+
+    public String getHttpProxyUser() {
+        return this.httpProxyUser;
+    }
+
+    public String getHttpProxyPass() {
+        return this.httpProxyPass;
+    }
+}

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
@@ -16,10 +16,6 @@ public class AWSDeviceFarmProxy {
     private String httpProxyPass;
     private boolean active = false;
 
-    AWSDeviceFarmProxy() {
-        this("", 0, "", "");
-    }
-
     AWSDeviceFarmProxy(String httpProxyFQDN, int httpProxyPort, String httpProxyUser, String httpProxyPass) {
         this.setHttpProxyFQDN(httpProxyFQDN);
         this.setHttpProxyPort(httpProxyPort);

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmProxy.java
@@ -1,10 +1,24 @@
 package org.jenkinsci.plugins.awsdevicefarm;
 
+import org.apache.http.HttpHost;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.UsernamePasswordCredentials;
+import org.apache.http.client.CredentialsProvider;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.ProxyAuthenticationStrategy;
+
 public class AWSDeviceFarmProxy {
     private String httpProxyFQDN;
     private int httpProxyPort;
     private String httpProxyUser;
     private String httpProxyPass;
+    private boolean active = false;
+
+    AWSDeviceFarmProxy() {
+        this("", 0, "", "");
+    }
 
     AWSDeviceFarmProxy(String httpProxyFQDN, int httpProxyPort, String httpProxyUser, String httpProxyPass) {
         this.setHttpProxyFQDN(httpProxyFQDN);
@@ -15,6 +29,11 @@ public class AWSDeviceFarmProxy {
 
     public void setHttpProxyFQDN(String value) {
         this.httpProxyFQDN = value;
+        this.setActive(true);
+    }
+
+    public void setActive(boolean value) {
+        this.active = value;
     }
 
     public void setHttpProxyPort(int value) {
@@ -33,6 +52,10 @@ public class AWSDeviceFarmProxy {
         return this.httpProxyFQDN;
     }
 
+    public boolean getActive() {
+        return this.active;
+    }
+
     public int getHttpProxyPort() {
         return this.httpProxyPort;
     }
@@ -43,5 +66,22 @@ public class AWSDeviceFarmProxy {
 
     public String getHttpProxyPass() {
         return this.httpProxyPass;
+    }
+
+    public CloseableHttpClient httpClientWithProxy() {
+        CredentialsProvider credentialProvider = new BasicCredentialsProvider();
+        credentialProvider.setCredentials(
+            new AuthScope(getHttpProxyFQDN(), getHttpProxyPort()),
+            new UsernamePasswordCredentials(getHttpProxyUser(), getHttpProxyPass())
+        );
+
+        HttpHost customProxy = new HttpHost(getHttpProxyFQDN(), getHttpProxyPort());
+        HttpClientBuilder clientBuilder = HttpClientBuilder.create();
+        clientBuilder
+            .setProxy(customProxy)
+            .setProxyAuthenticationStrategy(new ProxyAuthenticationStrategy())
+            .setDefaultCredentialsProvider(credentialProvider);
+
+        return clientBuilder.build();
     }
 }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1571,7 +1571,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @return The AWS Device Farm API object.
          */
         public AWSDeviceFarm getAWSDeviceFarm() {
-            return getDeviceFarmInstance(roleArn, akid, skid, null);
+            return getDeviceFarmInstance(roleArn, akid, skid, new AWSDeviceFarmProxy());
         }
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1401,11 +1401,11 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     }
 
     /**
-     * Proxy URL getter.
+     * Proxy FQDN getter.
      *
-     * @return The proxy URL.
+     * @return The proxy FQDN.
      */
-    public String getProxyUrl() {
+    public String getProxyFQDN() {
         return getDescriptor().httpProxyFQDN;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1401,6 +1401,42 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     }
 
     /**
+     * Proxy URL getter.
+     *
+     * @return The proxy URL.
+     */
+    public String getProxyUrl() {
+        return getDescriptor().httpProxyUrl;
+    }
+
+    /**
+     * Proxy Port getter.
+     *
+     * @return The proxy Port.
+     */
+    public int getProxyPort() {
+        return getDescriptor().httpProxyPort;
+    }
+
+    /**
+     * Proxy User getter.
+     *
+     * @return The proxy user.
+     */
+    public String getProxyUser() {
+        return getDescriptor().httpProxyUser;
+    }
+
+    /**
+     * Proxy Password getter.
+     *
+     * @return The proxy password.
+     */
+    public Secret getProxyPass() {
+        return getDescriptor().httpProxyPass;
+    }
+
+    /**
      * Getter for the Device Farm API.
      *
      * @return The Device Farm API.

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1526,6 +1526,47 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         }
 
         /**
+         * httpProxyUrl Setter
+         *
+         * @param httpProxyUrlValue
+         */
+        protected final void setHttpProxyUrl(String httpProxyUrlValue){
+            httpProxyUrl = httpProxyUrlValue;
+        }
+
+        /**
+         * httpProxyUrl Setter
+         *
+         * @param httpProxyPortValue
+         */
+        protected final void setHttpProxyUrl(int httpProxyPortValue){
+            httpProxyPort = httpProxyPortValue;
+        }
+
+        /**
+         * httpProxyUrl Setter
+         *
+         * @param httpProxyUserValue
+         */
+        protected final void setHttpProxyUser(String httpProxyUserValue){
+            httpProxyUser = httpProxyUserValue;
+        }
+
+        /**
+         * httpProxyPassword Setter
+         *
+         * @param httpProxyPassValue
+         */
+        protected final void setHttpProxyPass(String httpProxyPassValue){
+            httpProxyPass = Secret.fromString(httpProxyPassValue);
+        }
+
+        public AWSDeviceFarmProxy getProxy() {
+            AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
+            return proxyConfig;
+        }
+
+        /**
          * Return configured instance of the AWS Device Farm client.
          *
          * @return The AWS Device Farm API object.
@@ -1546,7 +1587,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                                                     final Secret skid) {
             AWSDeviceFarm adf;
             if (roleArn == null || roleArn.isEmpty()) {
-                return new AWSDeviceFarm(new BasicAWSCredentials(Secret.toString(akid), Secret.toString(skid)));
+                return new AWSDeviceFarm(new BasicAWSCredentials(Secret.toString(akid), Secret.toString(skid)), getProxy());
             } else {
                 return new AWSDeviceFarm(roleArn);
             }

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1406,7 +1406,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @return The proxy URL.
      */
     public String getProxyUrl() {
-        return getDescriptor().httpProxyUrl;
+        return getDescriptor().httpProxyFQDN;
     }
 
     /**
@@ -1484,7 +1484,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         public String roleArn;
         public Secret akid;
         public Secret skid;
-        public String httpProxyUrl;
+        public String httpProxyFQDN;
         public int httpProxyPort;
         public String httpProxyUser;
         public Secret httpProxyPass;
@@ -1526,25 +1526,25 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         }
 
         /**
-         * httpProxyUrl Setter
+         * httpProxyFQDN Setter
          *
-         * @param httpProxyUrlValue
+         * @param httpProxyFQDNValue
          */
-        protected final void setHttpProxyUrl(String httpProxyUrlValue){
-            httpProxyUrl = httpProxyUrlValue;
+        protected final void setHttpProxyFQDN(String httpProxyFQDNValue){
+            httpProxyFQDN = httpProxyFQDNValue;
         }
 
         /**
-         * httpProxyUrl Setter
+         * httpProxyPort Setter
          *
          * @param httpProxyPortValue
          */
-        protected final void setHttpProxyUrl(int httpProxyPortValue){
+        protected final void setHttpProxyPort(int httpProxyPortValue){
             httpProxyPort = httpProxyPortValue;
         }
 
         /**
-         * httpProxyUrl Setter
+         * httpProxyUser Setter
          *
          * @param httpProxyUserValue
          */
@@ -1562,7 +1562,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         }
 
         public AWSDeviceFarmProxy getProxy() {
-            return new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
+            return new AWSDeviceFarmProxy(httpProxyFQDN, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
         }
 
         /**
@@ -1571,7 +1571,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @return The AWS Device Farm API object.
          */
         public AWSDeviceFarm getAWSDeviceFarm() {
-            AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
+            AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyFQDN, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
             return getDeviceFarmInstance(roleArn, akid, skid, proxyConfig);
         }
 
@@ -1599,7 +1599,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @param roleArn the role arn
          * @param akid the access key
          * @param skid the secret key
-         * @param httpProxyUrl the proxy url
+         * @param httpProxyFQDN the proxy url
          * @param httpProxyPort the proxy port
          * @param httpProxyUser the proxy user
          * @param httpProxyPass the proxy pass
@@ -1609,7 +1609,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         public FormValidation doValidateCredentials(@QueryParameter String roleArn,
                                                     @QueryParameter String akid,
                                                     @QueryParameter String skid,
-                                                    @QueryParameter String httpProxyUrl,
+                                                    @QueryParameter String httpProxyFQDN,
                                                     @QueryParameter int httpProxyPort,
                                                     @QueryParameter String httpProxyUser,
                                                     @QueryParameter String httpProxyPass) {
@@ -1640,7 +1640,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                      }
                 }
 
-                AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass);
+                AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyFQDN, httpProxyPort, httpProxyUser, httpProxyPass);
                 AWSDeviceFarm deviceFarm = getDeviceFarmInstance(roleArn, Secret.fromString(akid), Secret.fromString(skid), proxyConfig);
                 // This does two things, validates access and secret key are valid and if they have access to device farm.
                 deviceFarm.getProjects();

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1571,7 +1571,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @return The AWS Device Farm API object.
          */
         public AWSDeviceFarm getAWSDeviceFarm() {
-            return getDeviceFarmInstance(roleArn, akid, skid, new AWSDeviceFarmProxy());
+            AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
+            return getDeviceFarmInstance(roleArn, akid, skid, proxyConfig);
         }
 
         /**

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1588,7 +1588,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             if (roleArn == null || roleArn.isEmpty()) {
                 return new AWSDeviceFarm(new BasicAWSCredentials(Secret.toString(akid), Secret.toString(skid)), getProxy());
             } else {
-                return new AWSDeviceFarm(roleArn);
+                return new AWSDeviceFarm(roleArn, getProxy());
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1599,7 +1599,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
          * @param roleArn the role arn
          * @param akid the access key
          * @param skid the secret key
-         * @param httpProxyFQDN the proxy url
+         * @param httpProxyFQDN the proxy fqdn
          * @param httpProxyPort the proxy port
          * @param httpProxyUser the proxy user
          * @param httpProxyPass the proxy pass

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1484,6 +1484,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         public String roleArn;
         public Secret akid;
         public Secret skid;
+        public String httpProxyUrl;
+        public int httpProxyPort;
+        public String httpProxyUser;
+        public Secret httpProxyPass;
 
         private List<String> projectsCache = new ArrayList<String>();
         private Map<String, List<String>> poolsCache = new HashMap<String, List<String>>();

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -1562,8 +1562,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         }
 
         public AWSDeviceFarmProxy getProxy() {
-            AWSDeviceFarmProxy proxyConfig = new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
-            return proxyConfig;
+            return new AWSDeviceFarmProxy(httpProxyUrl, httpProxyPort, httpProxyUser, httpProxyPass.getPlainText());
         }
 
         /**

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -19,7 +19,7 @@
             <f:password />
         </f:entry>
 
-        <f:entry title="HTTP Proxy FQDN" field="httpProxyFQDN" description="Http Proxy URL (proxytest.com)">
+        <f:entry title="HTTP Proxy FQDN" field="httpProxyFQDN" description="Http Proxy FQDN (proxytest.com)">
             <f:textbox />
         </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -36,6 +36,6 @@
         </f:entry>
 
         <f:validateButton title="Validate" method="validateCredentials" progress="Checking..." inline="true"
-        with="roleArn,akid,skid,httpProxyUrl,httpProxyUser,httpProxyPass"/>
+        with="roleArn,akid,skid,httpProxyUrl,httpProxyPort,httpProxyUser,httpProxyPass"/>
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -19,7 +19,7 @@
             <f:password />
         </f:entry>
 
-        <f:entry title="HTTP Proxy URL" field="httpProxyFQDN" description="Http Proxy URL (proxytest.com)">
+        <f:entry title="HTTP Proxy FQDN" field="httpProxyFQDN" description="Http Proxy URL (proxytest.com)">
             <f:textbox />
         </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -19,7 +19,7 @@
             <f:password />
         </f:entry>
 
-        <f:entry title="HTTP Proxy URL" field="httpProxyUrl" description="Http Proxy URL (proxytest.com)">
+        <f:entry title="HTTP Proxy URL" field="httpProxyFQDN" description="Http Proxy URL (proxytest.com)">
             <f:textbox />
         </f:entry>
 
@@ -36,6 +36,6 @@
         </f:entry>
 
         <f:validateButton title="Validate" method="validateCredentials" progress="Checking..." inline="true"
-        with="roleArn,akid,skid,httpProxyUrl,httpProxyPort,httpProxyUser,httpProxyPass"/>
+        with="roleArn,akid,skid,httpProxyFQDN,httpProxyPort,httpProxyUser,httpProxyPass"/>
     </f:section>
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/global.jelly
@@ -19,7 +19,23 @@
             <f:password />
         </f:entry>
 
+        <f:entry title="HTTP Proxy URL" field="httpProxyUrl" description="Http Proxy URL (proxytest.com)">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="HTTP Proxy Port" field="httpProxyPort" description="Http Proxy Port (80)">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="HTTP Proxy User" field="httpProxyUser" description="Http Proxy User">
+            <f:textbox />
+        </f:entry>
+
+        <f:entry title="HTTP Proxy Password" field="httpProxyPass" description="Http Proxy Password">
+            <f:password />
+        </f:entry>
+
         <f:validateButton title="Validate" method="validateCredentials" progress="Checking..." inline="true"
-        with="roleArn,akid,skid"/>
+        with="roleArn,akid,skid,httpProxyUrl,httpProxyUser,httpProxyPass"/>
     </f:section>
 </j:jelly>


### PR DESCRIPTION
Added proxy support that is not the same as defined in jenkins' java options or system properties. This is usual for cases where the company uses several proxies and you need to define a specific proxy to communicate with AWS for example. The proxy configuration is optional and compatible with others versions. If the user insert empty for proxy parameters will work.

<img width="1079" alt="Screen Shot 2020-06-27 at 4 25 07 PM" src="https://user-images.githubusercontent.com/10470628/85930487-2a716800-b893-11ea-89ab-f5f3bdfba996.png">
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
