### PR TITLE
Add VPC ENI view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,8 @@ vagrant_ansible_inventory_*
 .idea
 *.iml
 
+# VSCode
+.vscode
+
 # OS X
 .DS_Store

--- a/pom.xml
+++ b/pom.xml
@@ -31,14 +31,30 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk</artifactId>
-      <version>1.11.478</version>
+      <version>1.12.395</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.dataformat</groupId>
+          <artifactId>jackson-dataformat-cbor</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.jackson.core</groupId>
+          <artifactId>jackson-databind</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- TODO: Use Apache HttpComponents Client 4.x API instead: https://plugins.jenkins.io/apache-httpcomponents-client-4-api -->
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-        <version>4.4.9</version>
+        <version>4.4.13</version>
+    </dependency>
+
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+        <version>1.15</version>
     </dependency>
   </dependencies>
 
@@ -68,6 +84,11 @@
       <id>nikdabn</id>
       <name>Nikhil Dabhade</name>
       <email>nikdabn@amazon.com</email>
+    </developer>
+    <developer>
+      <id>wrydane</id>
+      <name>Dane Wrye</name>
+      <email>wrydane@amazon.com</email>
     </developer>
   </developers>
 

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -41,6 +41,7 @@ import com.amazonaws.services.devicefarm.model.Test;
 import com.amazonaws.services.devicefarm.model.TestType;
 import com.amazonaws.services.devicefarm.model.Upload;
 import com.amazonaws.services.devicefarm.model.VPCEConfiguration;
+import com.amazonaws.services.devicefarm.model.VpcConfig;
 import hudson.EnvVars;
 import hudson.Extension;
 import hudson.FilePath;
@@ -193,6 +194,11 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     public String vpceServiceName;
     public Boolean ifVpce;
 
+    // VPC ENI Configuration
+    public String vpcId = projectName;
+    public String securityGroups;
+    public String subnetIds;
+
     public Boolean deviceLocation;
     public Double deviceLatitude;
     public Double deviceLongitude;
@@ -262,6 +268,9 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @param deviceLatitude                The specified device latitude.
      * @param deviceLongitude               The specified device longitude.
      * @param ifVpce                        Checked if VPCE config is enabled.
+     * @param vpcId                         The id of the VPC config
+     * @param securityGroups                The security groups associated with the VPC config
+     * @param subnetIds                     The ids of the subnets associated with the VPC config
      * @param radioDetails                  Whether the radio details would be specified.
      * @param ifWifi
      * @param ifNfc
@@ -324,6 +333,9 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                                  Boolean ifAppPerformanceMonitoring,
                                  Boolean ignoreRunError,
                                  Boolean ifVpce,
+                                 String vpcId,
+                                 String securityGroups,
+                                 String subnetIds,
                                  Boolean ifSkipAppResigning,
                                  String vpceServiceName ) {
         this.projectName = projectName;
@@ -367,6 +379,9 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         this.deviceLatitude = deviceLatitude;
         this.deviceLongitude = deviceLongitude;
         this.ifVpce = ifVpce;
+        this.vpcId = vpcId;
+        this.securityGroups = securityGroups;
+        this.subnetIds = subnetIds;
         this.ifSkipAppResigning = ifSkipAppResigning;
         this.radioDetails = radioDetails;
         this.ifWifi = ifWifi;
@@ -550,10 +565,16 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                     }
                 }
             }
-
             // Get AWS Device Farm project from user provided name.
             writeToLog(log, String.format("Using Project '%s'", projectName));
             Project project = adf.getProject(projectName);
+
+            VpcConfig vpcSettings = project.getVpcConfig();
+            if (vpcSettings != null) {
+                securityGroups = vpcSettings.getSecurityGroupIds().toString();
+                subnetIds = vpcSettings.getSubnetIds().toString();
+                project.setVpcConfig(null);
+            }
 
             // Accept 'ADF_DEVICE_POOL' build parameter as an overload from job configuration.
             String devicePoolParameter = parameters.get("AWSDEVICEFARM_DEVICE_POOL");
@@ -1380,6 +1401,54 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      */
     public String getRoleArn() {
         return getDescriptor().roleArn;
+    }
+
+    /**
+     * Gets vpcId for textbox
+     *
+     * @return The role ARN.
+     */
+    public String getVpcString() {
+        AWSDeviceFarm adf = getAWSDeviceFarm();
+        try {
+            Project proj = adf.getProject(projectName);
+            VpcConfig vpcSettings = proj.getVpcConfig();
+            return vpcSettings.getVpcId();
+        } catch (Exception error) {
+            return "";
+        }
+    }
+
+    /**
+     * Gets string representing subnet ids for textbox
+     *
+     * @return The role ARN.
+     */
+    public String getSubnetString() {
+        AWSDeviceFarm adf = getAWSDeviceFarm();
+        try {
+            Project proj = adf.getProject(projectName);
+            VpcConfig vpcSettings = proj.getVpcConfig();
+            return vpcSettings.getSubnetIds().toString();
+        } catch (Exception error) {
+            return "";
+        }
+    }
+
+    /**
+     * Gets string representing security groups for textbox
+     *
+     * @return The role ARN.
+     */
+    public String getSecurityGroupString() {
+        AWSDeviceFarm adf = getAWSDeviceFarm();
+        try {
+            Project proj = adf.getProject(projectName);
+            VpcConfig vpcSettings = proj.getVpcConfig();
+            return vpcSettings.getSecurityGroupIds().toString();
+        } catch (Exception error) {
+            return "";
+        }
     }
 
     /**

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -4,7 +4,7 @@
   <f:validateButton title="refresh" method="refresh" progress="Checking..." inline="true" />
 
   <f:entry title="Project" field="projectName" description="[Required] Select your AWS Device Farm project.">
-    <f:select default="Select your project" style="width:100%; padding-right:5px; margin-right:5px" inline="true" />
+    <f:select default="Select your project" style="width:100%; padding-right:5px; margin-right:5px" inline="true" clazz="projectSelect"/>
   </f:entry>
 
   <f:entry title="Device Pool" field="devicePoolName" description="[Required] Select your AWS Device Farm device pool.">
@@ -41,6 +41,17 @@
           <f:select style="width:100%" inline="true"/>
         </f:entry>
     </f:optionalBlock>
+    <f:entry title="VPC ENI" description="[Optional] VPC config for your selected project. Note - you may need to refresh your browser after applying a new project selection to see updated VPC">
+      <f:entry title="VPC ID" field="vpcId">
+        <f:readOnlyTextbox clazz="vpcId" value="${instance.vpcString}"/>
+      </f:entry>
+      <f:entry title="Security Groups" field="securityGroups">
+        <f:readOnlyTextbox value="${instance.securityGroupString}"/>
+      </f:entry>
+      <f:entry title="Subnet IDs" field="subnetIds">
+        <f:readOnlyTextbox value="${instance.subnetString}"/>
+      </f:entry>
+    </f:entry>
   </f:section>
 
   <f:section title="Choose test to run">
@@ -257,4 +268,5 @@
     </f:entry>
 
   </f:section>
+  <script src="${rootURL}/plugin/aws-device-farm/config.js"/>
 </j:jelly>

--- a/src/main/webapp/config.js
+++ b/src/main/webapp/config.js
@@ -1,0 +1,21 @@
+let vpceSelect = document.querySelector("[name='ifVpce']");
+const vpcTextbox = document.querySelector(".vpcId");
+const projectSelect = document.querySelector(".projectSelect");
+
+// disable vpce select option if project already has VPC Settings
+if (vpcTextbox && vpcTextbox.value) {
+    vpceSelect.disabled = true;
+}
+
+// check again for VPC status every time a new project is selected
+const handleClick = () => {
+    if (vpcTextbox && vpcTextbox.value) {
+        vpceSelect.disabled = true;
+    } else {
+        vpceSelect.disabled = false;
+    }
+}
+
+projectSelect.addEventListener("click", handleClick);
+
+


### PR DESCRIPTION
*Description of changes:*
Allow users to view VPC ENI settings when configuring their AWS Device Farm run


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
