### PR TITLE
De-increment plugin version number

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.7</version>
+    <version>3.6</version>
   </parent>
 
   <groupId>org.jenkins-ci.plugins</groupId>


### PR DESCRIPTION
de-increment plugin version number which was mistakenly incremented manually

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
