### PR TITLE
Add path and archive options to saving results locally

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -119,6 +119,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
     public String testSpecName;
     public String environmentToRun;
     public Boolean storeResults;
+    public String resultsPath;
+    public Boolean archiveResults;
     public Boolean isRunUnmetered;
 
     // Built-in Fuzz
@@ -231,8 +233,10 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
      * @param runName                       The name of the run.
      * @param testToRun                     The type of test to be run.
      * @param storeResults                  Download the results to a local archive.
+     * @param resultsPath                   Path to where the results will be saved to.
+     * @param archiveResults                Whether to save results directly to the artifacts folder, saving them as build artifacts, or use the workspace folder.
      * @param eventCount                    The number of fuzz events to run.
-     * @param eventThrottle                 The the fuzz event throttle count.
+     * @param eventThrottle                 The fuzz event throttle count.
      * @param seed                          The initial seed of fuzz events.
      * @param username                      Username to use if explorer encounters a login form.
      * @param password                      Password to use if explorer encounters a login form.
@@ -284,6 +288,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                                  String runName,
                                  @Nonnull String testToRun,
                                  Boolean storeResults,
+                                 String resultsPath,
+                                 Boolean archiveResults,
                                  Boolean isRunUnmetered,
                                  String eventCount,
                                  String eventThrottle,
@@ -335,6 +341,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
         this.appArtifact = appArtifact;
         this.runName = runName;
         this.storeResults = storeResults;
+        this.resultsPath = resultsPath;
+        this.archiveResults = archiveResults;
         this.isRunUnmetered = isRunUnmetered;
         this.eventCount = eventCount;
         this.eventThrottle = eventThrottle;
@@ -660,7 +668,8 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
             // Download results archive and store it.
             if (storeResults) {
                 // Create results storage directory which will contain the unzip logs/screenshots pulled from AWS Device Farm.
-                FilePath resultsDir = new FilePath(artifactsDir, "AWS Device Farm Results");
+                FilePath resultsRootDir = archiveResults == null || archiveResults ? artifactsDir : workspace;
+                FilePath resultsDir = new FilePath(resultsRootDir, StringUtils.isBlank(resultsPath) ? "AWS Device Farm Results" : resultsPath);
                 resultsDir.mkdirs();
                 writeToLog(log, String.format("Storing AWS Device Farm results in directory %s", resultsDir));
 
@@ -684,7 +693,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
                         localArtifact.copyFrom(artifactUrl);
                     }
                 }
-                writeToLog(log, String.format("Results archive saved in %s", artifactsDir.getName()));
+                writeToLog(log, String.format("Results archive saved in %s", resultsRootDir.getName()));
             }
 
             // Set Jenkins build result based on AWS Device Farm test result.

--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -33,10 +33,15 @@
   <f:entry>
     <f:checkbox name="isRunUnmetered" field="isRunUnmetered" title="Run on Unmetered Device Slots." checked="${instance.isRunUnmetered}" inline="true" />
   </f:entry>
-  
-  <f:entry>
-    <f:checkbox name="storeResults" title="Store test results locally." checked="${instance.storeResults}"/>
-  </f:entry>
+
+  <f:optionalBlock name="storeResults" title="Store test results locally." checked="${instance.storeResults}" inline="true">
+    <f:entry title="Results path" field="resultsPath" description="Path to where the results will be saved to.">
+      <f:textbox default="AWS Device Farm Results"/>
+    </f:entry>
+    <f:entry title="Archive results" description="Whether to save results directly to the artifacts folder, saving them as build artifacts, or use the workspace folder.">
+      <f:checkbox field="archiveResults" name="archiveResults" checked="${instance.archiveResults}" default="true"/>
+    </f:entry>
+  </f:optionalBlock>
 
   <f:entry>
     <f:checkbox name="ignoreRunError" field="ignoreRunError" title="Ignore Device Farm errors in build result." checked="${instance.ignoreRunError}" inline="true" />

--- a/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorderTest.java
@@ -36,7 +36,7 @@ public class AWSDeviceFarmRecorderTest {
         FreeStyleProject p = j.createFreeStyleProject();
         AWSDeviceFarmRecorder rec = new AWSDeviceFarmRecorder(
                 "TestProjectName", "TestDevicePool", null, null,
-                null, null, "APPIUM_JAVA_JUNIT", false, false, null,
+                null, null, "APPIUM_JAVA_JUNIT", false, "AWS Device Farm Results", true, false, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null, null, null,
                 null, null, null, null, null, null,


### PR DESCRIPTION
There are two different uses cases we have that the existing options didn't cover:

1. We run multiple Device Farm jobs in a single build and enabling saving results locally overrides the previous run files.

   We've added a new option "Results path" which lets us set a unique path per run so we no longer have conflicts.

2. The results are saved directly to the artifacts directory. That means we can't run our post-processing actions on them without unarchiving then re-archiving them. We also can't save only part of the results.

   We've added a second new boolean option "Archive results" that when unchecked will save results directly to the workspace folder instead. Then when we are ready we can archive all or part of them later in the build.

We've forked the plugin and have been running this change in production without issues for a few months now. Users should not see any behavior changes with the upgrade since the default options match current values.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
