### PR TITLE
Added support for Device Locale

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder/config.jelly
@@ -266,6 +266,12 @@
         <f:textbox default="-122.3941"/>
       </f:entry>
     </f:optionalBlock>
+
+    <f:optionalBlock name="deviceLocaleFlag" title="Specify Device Locale" checked="${instance.deviceLocaleFlag}" inline="true">
+      <f:entry title="Device Locale" field="deviceLocale" description="[Optional] Add the device locale." >
+        <f:textbox />
+      </f:entry>
+    </f:optionalBlock>
   </f:section>
 
   <f:section title="Execution Information">


### PR DESCRIPTION
**Description of changes:**
This pull request adds support for device locale in the plugin. Additional, changes includes the UI of the plugin which takes: 1) Flag to indicate that users want to add the device local 2) Value field to input the actual device locale.

The screenshot of the UI (indicated by config.jelly) file looks like below:

<img width="1121" height="358" alt="Screenshot 2025-07-30 at 9 31 15 PM" src="https://github.com/user-attachments/assets/804282dd-936f-4cb9-9e92-e87ecac46f95" />


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
