### PR TITLE
Support for marking Jenkins stage as failed when jobs are skipped

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmRecorder.java
@@ -774,6 +774,7 @@ public class AWSDeviceFarmRecorder extends Recorder implements SimpleBuildStep {
 
             // Set Jenkins build result based on AWS Device Farm test result.
             build.setResult(action.getBuildResult(ignoreRunError));
+            writeToLog(log, String.format("Marking jenkins stage result as: %s", action.getBuildResult(ignoreRunError)));
         } catch (AWSDeviceFarmException e) {
             writeToLog(log, e.getMessage());
             return;

--- a/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
+++ b/src/main/java/org/jenkinsci/plugins/awsdevicefarm/AWSDeviceFarmTestResult.java
@@ -79,8 +79,6 @@ public class AWSDeviceFarmTestResult extends TestResult {
             this.errorCount = run.getCounters().getErrored();
             this.skipCount = run.getCounters().getSkipped();
 
-            //this.duration =
-
             try {
                 this.stopCount = run.getCounters().getStopped();
             } catch (NullPointerException e) {
@@ -245,7 +243,7 @@ public class AWSDeviceFarmTestResult extends TestResult {
      */
     public Result getBuildResult(Boolean ignoreRunError) {
         if (ignoreRunError != null && ignoreRunError && ExecutionResult.ERRORED.equals(result)) {
-            if (totalCount == skipCount) {
+            if (skipCount > 0) {
                 result = ExecutionResult.SKIPPED;
             } else if (stopCount > 0) {
                 result = ExecutionResult.STOPPED;
@@ -255,6 +253,11 @@ public class AWSDeviceFarmTestResult extends TestResult {
                 result = ExecutionResult.WARNED;
             } else {
                 result = ExecutionResult.PASSED;
+            }
+        }
+        if (!ExecutionResult.ERRORED.equals(result)) {
+            if (skipCount > 0) {
+                result = ExecutionResult.SKIPPED;
             }
         }
         return resultMap.get(result);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This change adds an extra check for checking if device farm jobs are skipped.
If they are, the jenkins stage is marked as failure as there is no SKIPPED status in Jenkins.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
